### PR TITLE
Update constructor so that it is compatible with PHP 7

### DIFF
--- a/XML/Serializer.php
+++ b/XML/Serializer.php
@@ -598,7 +598,7 @@ class XML_Serializer extends PEAR
      *
      * @access public
      */
-    function XML_Serializer( $options = null )
+    function __construct( $options = null )
     {
         $this->PEAR();
         if (is_array($options)) {

--- a/XML/Serializer.php
+++ b/XML/Serializer.php
@@ -598,7 +598,7 @@ class XML_Serializer extends PEAR
      *
      * @access public
      */
-    function __construct( $options = null )
+    function __construct($options = null)
     {
         $this->PEAR();
         if (is_array($options)) {
@@ -607,6 +607,18 @@ class XML_Serializer extends PEAR
             $this->options = $this->_defaultOptions;
         }
     }
+	
+	/**
+     * Constructor
+     *
+     * @param mixed $options array containing options for the serialization
+     *
+     * @access public
+     */
+	function XML_Serializer($options = null)
+	{
+		$self::__construct($options);
+	}
 
     /**
      * Return the package version number

--- a/XML/Serializer.php
+++ b/XML/Serializer.php
@@ -607,18 +607,18 @@ class XML_Serializer extends PEAR
             $this->options = $this->_defaultOptions;
         }
     }
-	
-	/**
+
+    /**
      * Constructor
      *
      * @param mixed $options array containing options for the serialization
      *
      * @access public
      */
-	function XML_Serializer($options = null)
-	{
-		$self::__construct($options);
-	}
+    function XML_Serializer($options = null)
+    {
+        self::__construct($options);
+    }
 
     /**
      * Return the package version number

--- a/XML/Unserializer.php
+++ b/XML/Unserializer.php
@@ -432,7 +432,7 @@ class XML_Unserializer extends PEAR
      *
      * @access public
      */
-    function XML_Unserializer($options = null)
+    function __construct($options = null)
     {
         if (is_array($options)) {
             $this->options = array_merge($this->_defaultOptions, $options);

--- a/XML/Unserializer.php
+++ b/XML/Unserializer.php
@@ -440,18 +440,18 @@ class XML_Unserializer extends PEAR
             $this->options = $this->_defaultOptions;
         }
     }
-	
-	/**
+
+    /**
      * constructor
      *
      * @param mixed $options array containing options for the unserialization
      *
      * @access public
      */
-	function XML_Unserializer($options = null)
-	{
-		self::__construct($options);
-	}
+    function XML_Unserializer($options = null)
+    {
+        self::__construct($options);
+    }
 
     /**
      * return API version

--- a/XML/Unserializer.php
+++ b/XML/Unserializer.php
@@ -440,6 +440,18 @@ class XML_Unserializer extends PEAR
             $this->options = $this->_defaultOptions;
         }
     }
+	
+	/**
+     * constructor
+     *
+     * @param mixed $options array containing options for the unserialization
+     *
+     * @access public
+     */
+	function XML_Unserializer($options = null)
+	{
+		self::__construct($options);
+	}
 
     /**
      * return API version


### PR DESCRIPTION
PHP 7 throws an E_DEPRECATED message when PHP 4 style constructor is used. This PR fixes that.

More info - 
http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors