### PR TITLE
require pear-core-minimal instead of full pear installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "type": "library",
     "require": {
         "ext-xml": "*",
-        "pear/pear": "*",
+        "pear/pear-core-minimal": "*",
         "pear/xml_parser": "*",
         "pear/xml_util": "*"
     },


### PR DESCRIPTION
is it possible to require only pear-core-minimal instead of full pear installation for composer install?

Works for me, but I have quite a small use case for the lib.